### PR TITLE
Pin provider-aws-s3 to v1

### DIFF
--- a/template/upbound.yaml
+++ b/template/upbound.yaml
@@ -7,7 +7,7 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-aws-s3
-    version: '>=v1.22.0'
+    version: '^v1.22.0'
   - apiVersion: pkg.crossplane.io/v1
     kind: Function
     package: xpkg.upbound.io/crossplane-contrib/function-auto-ready


### PR DESCRIPTION
### Description of your changes

The official v2 providers don't work in Crossplane v1, since they require a UXP license. Pin our provider dependency to v1 for now so that this template works in v1 clusters.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

CI!
